### PR TITLE
VAWS-311: Rename app to Visualize with Code / AWS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Utoolity
+Copyright (c) 2021-2024 Utoolity
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Visualize with AWS (Samples)
+# Visualize with Code / AWS (Samples)
 
-This repository provides samples for [Visualize with AWS](https://marketplace.atlassian.com/search?query=%22Visualize%20with%20AWS%22), a Utoolity solution to maintain and render declarative charts and diagrams as code alongside your Jira issues and Confluence pages.
+This repository provides samples for [Visualize with Code / AWS](https://marketplace.atlassian.com/search?query=%22Visualize%20with%20Code%22), a Utoolity solution to maintain and render declarative charts and diagrams as code alongside your Jira issues and Confluence pages.
 
 ## Supported visualization languages
 
-Visualize with AWS currently supports these visualization grammars:
+Visualize with Code / AWS currently supports these visualization grammars:
 
 * [Vega](https://vega.github.io/vega/)
 * [Vega-Lite](https://vega.github.io/vega-lite/)

--- a/plantuml/app/visualize-with-code-use-case.puml
+++ b/plantuml/app/visualize-with-code-use-case.puml
@@ -2,7 +2,7 @@
 top to bottom direction
 actor Author
 actor User
-rectangle "Visualize with AWS" {
+rectangle "Visualize with Code / AWS" {
   Author --> (define diagram)
   (define diagram) .> (diagram) : renders
   (diagram) --> User


### PR DESCRIPTION
Merge candidate

---

NOTE: This is going to be a two step operation, where we'll first rename the app to 'Visualize with Code / AWS' to ease the transition for users and search engines, while being pragmatic on edge case (file names and other non purely textual references), and once this has stabilized for a while we'll ultimately converge to 'Visualize with Code' only. 